### PR TITLE
Version was not correct in metadata

### DIFF
--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -20,7 +20,7 @@
     </fileSets>
     <requiredProperties>
         <requiredProperty key="kotlinVersion">
-            <defaultValue>1.0.0-beta-1103</defaultValue>
+            <defaultValue>1.0.5-2</defaultValue>
         </requiredProperty>
     </requiredProperties>
 </archetype-descriptor>


### PR DESCRIPTION
The `kotlin.version` set in `archetype-metadata.xml` was still `1.0.0-beta-1103`, not what the README says.